### PR TITLE
Added multiple languages support

### DIFF
--- a/LookupDropdown/ControlManifest.Input.xml
+++ b/LookupDropdown/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <manifest>
-  <control namespace="DR" constructor="LookupDropdown" version="0.0.49" display-name-key="LookupDropdown" description-key="PCF to render a lookup field as a dropdown. (Optional) Include record image, Customize record text, Open record button." control-type="standard" preview-image="img/lookupdropdown.png">
+  <control namespace="DR" constructor="LookupDropdown" version="0.0.50" display-name-key="LookupDropdown" description-key="PCF to render a lookup field as a dropdown. (Optional) Include record image, Customize record text, Open record button." control-type="standard" preview-image="img/lookupdropdown.png">
 
     <property name="lookupfield" display-name-key="Lookup Field" description-key="Lookup field to render as dropdown" of-type="Lookup.Simple" usage="bound" required="true" />
     <property name="customtext" display-name-key="Custom Text" description-key="(Optional) customize display text with any text attributes of the record. put attribute schema names between curly braces {}. Ex. {new_firstname} {new_lastname}. Leave blank to show record primaryname." of-type="SingleLine.Text" usage="input" />
@@ -20,6 +20,8 @@
 
     <resources>
       <code path="index.ts" order="1"/>
+      <resx path="strings/LookupDropdown.1033.resx" version="1.0.0" />
+      <resx path="strings/LookupDropdown.1036.resx" version="1.0.0" />
     </resources>
    
     <feature-usage>

--- a/LookupDropdown/ControlManifest.Input.xml
+++ b/LookupDropdown/ControlManifest.Input.xml
@@ -7,13 +7,17 @@
     <property name="customselecttext" display-name-key="Custom Select Text" description-key="(Optional) Custom text for dropdown selector text (default = Select)." of-type="SingleLine.Text" usage="input" />
     <property name="dependentlookupfield" display-name-key="Dependent Lookup Field" description-key="(Optional) Dependent Lookup field. Use when Related Records Filtering is set on the Field Properties." of-type="Lookup.Simple" usage="bound" />
 
-
     <property name="showRecordImage" display-name-key="Show Record Image" description-key="Show the record image beside the text." of-type="Enum" usage="input" required="true">
       <value name="false" display-name-key="false" description-key="False" default="true">false</value>
       <value name="true" display-name-key="true" description-key="True">true</value>     
     </property>
 
     <property name="showOpenRecordButton" display-name-key="Show Open Record Button" description-key="Show a button next to the dropdown to open the selected record form." of-type="Enum" usage="input" required="true">
+      <value name="false" display-name-key="false" description-key="False" default="true">false</value>
+      <value name="true" display-name-key="true" description-key="True">true</value>     
+    </property>
+
+    <property name="sortByTextValue" display-name-key="Sort By Text Value" description-key="Sort the dropdown list by the displayed text value instead of the default lookup view sorting order." of-type="Enum" usage="input" required="true">
       <value name="false" display-name-key="false" description-key="False" default="true">false</value>
       <value name="true" display-name-key="true" description-key="True">true</value>     
     </property>

--- a/LookupDropdown/components/LookupDropdown.tsx
+++ b/LookupDropdown/components/LookupDropdown.tsx
@@ -112,9 +112,9 @@ const LookupDropdown = ():JSX.Element => {
 
   // MAIN RENDERING
   if (isLoading) {
-    return <div>Loading...</div>
+    return <div>{pcfcontext.context.resources.getString("Loading...")}</div>
   } if (isError) {
-    return <div>Error fetching data...</div>
+    return <div>{pcfcontext.context.resources.getString("Error fetching data...")}</div>
   } else {
     return (
       <>

--- a/LookupDropdown/services/PcfContextService.ts
+++ b/LookupDropdown/services/PcfContextService.ts
@@ -21,6 +21,7 @@ export class PcfContextService {
   dependentValue:ComponentFramework.LookupValue | undefined;
   dependentEntityName:string;
   filterRelationshipName:string;
+  customText: string | null | undefined;
   onChange: (selectedOption?: ComponentFramework.LookupValue[] | undefined) => void;
 
   constructor (props?:IPcfContextServiceProps) {
@@ -37,6 +38,11 @@ export class PcfContextService {
         : undefined
       this.dependentEntityName = (props.context.parameters.lookupfield as any).dependentAttributeType ?? ''
       this.filterRelationshipName = (props.context.parameters.lookupfield as any).filterRelationshipName ?? ''
+      if (this.context.parameters.customtext.raw)
+      {
+        this.customText = this.context.parameters.customtext.raw.indexOf("##") > -1 ? this.context.parameters.customtext.raw.split("__").find(langcustomtext => langcustomtext.split("##")[0] === this.context.userSettings.languageId.toString())?.split("##")[1] : this.context.parameters.customtext.raw;
+      }
+      
       this.onChange = props.onChange
     }
   }
@@ -57,13 +63,11 @@ export class PcfContextService {
 
   getRecordText (record:ComponentFramework.WebApi.Entity, primaryname:string):string {
     // Default = record primaryname
-    if (this.context.parameters.customtext.raw == null) {
+    if (!this.customText) {
       return record[`${primaryname}`]
     } else {
       // Custom text
-      let customtext = this.context.parameters.customtext.raw.indexOf("##") > -1 ? this.context.parameters.customtext.raw.split("__").find(langcustomtext => langcustomtext.split("##")[0] === this.context.userSettings.languageId.toString())?.split("##")[1] : this.context.parameters.customtext.raw;
-      if (customtext)
-      {
+      let customtext = this.customText;
         this.CustomTextAttributes().forEach(attribute => {
           // check if there is a formated value for the attribute (ex. Choice, Date, Lookup etc)
           const formatedValue = record[`${attribute}@OData.Community.Display.V1.FormattedValue`] ??
@@ -73,8 +77,6 @@ export class PcfContextService {
         })
   
         return customtext
-      }
-      return record[`${primaryname}`]
     }
   }
 

--- a/LookupDropdown/services/PcfContextService.ts
+++ b/LookupDropdown/services/PcfContextService.ts
@@ -136,7 +136,19 @@ export class PcfContextService {
     const result = await this.context.webAPI
       .retrieveMultipleRecords(entityname, `?fetchXml=${fetchxmlstring}`)
 
-    return result.entities ?? []
+    if (result.entities)
+    {
+      if (this.context.parameters.sortByTextValue.raw === 'true')
+      {
+        return result.entities?.sort((a, b) => {
+          const aText = this.getRecordText(a, primaryname);
+          const bText = this.getRecordText(b, primaryname);
+          return aText.localeCompare(bText);
+        });
+      }
+      return result.entities;
+    }
+    return [];
   }
 
   private getManyToOneLinkEntity (manytoonerelationship:any) :HTMLElement {

--- a/LookupDropdown/services/PcfContextService.ts
+++ b/LookupDropdown/services/PcfContextService.ts
@@ -48,7 +48,7 @@ export class PcfContextService {
   }
 
   SelectText ():string {
-    return `--${this.context.parameters.customselecttext.raw ?? 'Select'}--`
+    return `--${this.context.parameters.customselecttext.raw ?? this.context.resources.getString("Select")}--`
   }
 
   replaceAll (string:string, search:string, replace:string) {
@@ -61,16 +61,20 @@ export class PcfContextService {
       return record[`${primaryname}`]
     } else {
       // Custom text
-      let customtext = this.context.parameters.customtext.raw
-      this.CustomTextAttributes().forEach(attribute => {
-        // check if there is a formated value for the attribute (ex. Choice, Date, Lookup etc)
-        const formatedValue = record[`${attribute}@OData.Community.Display.V1.FormattedValue`] ??
-                              record[`_${attribute}_value@OData.Community.Display.V1.FormattedValue`] ??
-                              record[`${attribute}`]
-        customtext = this.replaceAll(customtext, `{${attribute}}`, formatedValue ?? '')
-      })
-
-      return customtext
+      let customtext = this.context.parameters.customtext.raw.indexOf("##") > -1 ? this.context.parameters.customtext.raw.split("__").find(langcustomtext => langcustomtext.split("##")[0] === this.context.userSettings.languageId.toString())?.split("##")[1] : this.context.parameters.customtext.raw;
+      if (customtext)
+      {
+        this.CustomTextAttributes().forEach(attribute => {
+          // check if there is a formated value for the attribute (ex. Choice, Date, Lookup etc)
+          const formatedValue = record[`${attribute}@OData.Community.Display.V1.FormattedValue`] ??
+                                record[`_${attribute}_value@OData.Community.Display.V1.FormattedValue`] ??
+                                record[`${attribute}`]
+          customtext = this.replaceAll(customtext!, `{${attribute}}`, formatedValue ?? '')
+        })
+  
+        return customtext
+      }
+      return record[`${primaryname}`]
     }
   }
 

--- a/LookupDropdown/strings/LookupDropdown.1033.resx
+++ b/LookupDropdown/strings/LookupDropdown.1033.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Select" xml:space="preserve">
+    <value>Select</value> 
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Loading...</value> 
+  </data>
+  <data name="Error fetching data..." xml:space="preserve">
+    <value>Error fetching data...</value> 
+  </data>
+</root>

--- a/LookupDropdown/strings/LookupDropdown.1036.resx
+++ b/LookupDropdown/strings/LookupDropdown.1036.resx
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Select" xml:space="preserve">
+    <value>Sélectionner</value> 
+  </data>
+  <data name="Loading..." xml:space="preserve">
+    <value>Chargement...</value> 
+  </data>
+  <data name="Error fetching data..." xml:space="preserve">
+    <value>Erreur lors de l'obtention des données...</value> 
+  </data>
+</root>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ react-query : https://react-query.tanstack.com/
 | Parameter         | Description                                                                                  | Default     |
 |-------------------|----------------------------------------------------------------------------------------------|----------   |
 | lookupfield  | REQUIRED: Bound Lookup field to render as dropdown                             |             |
-| customtext  | OPTIONAL: Customize display text with any text attributes of the record. put attribute schema names between brackets {}. Ex. {new_firstname} {new_lastname}. Leave blank to show record primaryname|             |
+| customtext  | OPTIONAL: Customize display text with any text attributes of the record. put attribute schema names between brackets {}. Ex. {new_firstname} {new_lastname}. Leave blank to show record primaryname. Support multiple language using the format LANGUAGECODE1##{attrib1lang1} {attrib2lang1}__LANGUAGECODE2##{attrib1lang2} {attrib1lang2} ex: 1033##{new_nameen}__1036##{new_namefr} |             |
 | customselecttext    | OPTIONAL: Custom text for dropdown selector text (default = Select)    | |
 | dependentlookupfield | OPTIONAL: Dependent Lookup field. Use when Related Records Filtering is set on the Field Properties    | |
 | showRecordImage   | Show the record image beside the text | false  |

--- a/stories/LookupDropdown.renderGenerator.ts
+++ b/stories/LookupDropdown.renderGenerator.ts
@@ -37,6 +37,7 @@ export const renderGenerator = () => {
             lookupfield: LookupPropertyMock,
             showOpenRecordButton: EnumPropertyMock<"false" | "true">,
             showRecordImage: EnumPropertyMock<"false" | "true">,
+            sortByTextValue: EnumPropertyMock<"false" | "true">,
           },
           container
         );


### PR DESCRIPTION
- Supports showing different fields values based on user's language setting using the existing customtext property
- Backward compatible with existing fonctionnality of customtext property
- Added localization for French using resx
- Added sort by displayed text instead of using lookup view default sort order

As an example, using customtext with value: 1033##{crefd_name1en} {crefd_name2en}__1036##{crefd_name1fr} {crefd_name2fr}
would show:
For English:
<img width="536" alt="image" src="https://github.com/drivardxrm/LookupDropdown.PCF/assets/18577090/b5cbf648-1035-4183-a226-47f9e5e078c4">

For French: 
<img width="535" alt="image" src="https://github.com/drivardxrm/LookupDropdown.PCF/assets/18577090/4c9aa7a1-028e-452b-899c-7787b6b6b22e">
